### PR TITLE
Enable usage of additional_metadata inside meta

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -52,6 +52,29 @@ are used:
 
 ## Changelog
 
+- Add support for rendering additional metadata
+    - Upstream issue: https://github.com/dbt-labs/dbt-core/issues/7021
+    - Fork PR: https://github.com/PicnicSupermarket/dbt-docs/pull/1
+
+  To enable users in adding any metadata to dbt docs in a structured way. The key `meta.additional_meta` is treated
+  differently and rendered in a structured way on the webpage. The structure of `meta` and `additional_meta` should be
+  as follows:
+
+  ```
+      meta:
+        meta_stuff: meta_stuff
+        additional_meta:
+          - - foo: bar
+            - baz: qux
+          - - fiz: buz
+            - bla: bla
+  ```
+
+  `meta_additional` enables users to add rows under the row that contains `meta`. It has to be a list of lists, where
+  each inner list contains dictionaries with one key-val pair. The
+  index of the outer list defines the position of the row, the index of the inner list(s) defines the position inside
+  the row.
+
 - Add support for mermaid.js graphs
   - Upstream PR: https://github.com/dbt-labs/dbt-docs/pull/375
   - Upstream issue: https://github.com/dbt-labs/dbt-docs/issues/338

--- a/FORK.md
+++ b/FORK.md
@@ -1,64 +1,62 @@
 # dbt-docs fork
 
-This repository holds a fork of
-[dbt-docs](https://github.com/dbt-labs/dbt-docs) (referred as
-`upstream`). Its main purpose is to serve as a staging area for some
+This repository holds a fork of [dbt-docs](https://github.com/dbt-labs/dbt-docs)
+(referred as `upstream`). Its main purpose is to serve as a staging area for some
 features we're developing.
 
-We intend to follow upstream development, and diverge from it as
-little as possible. Therefore:
-- Every PR in this repository must be accompanied by a PR upstream,
-  and/or an issue upstream where the feature is discussed with
-  upstream developers.
-- If a feature developed in this repository ends up being developed
-  upstream with an alternative implementation, the upstream implementation
-  will be kept (to the extent it doesn't break anything or conflict
-  with other features).
-  
+We intend to follow upstream development, and diverge from it as little as possible.
+Therefore:
+
+- Every PR in this repository must be accompanied by a PR upstream, and/or an issue
+  upstream where the feature is discussed with upstream developers.
+- If a feature developed in this repository ends up being developed upstream with an
+  alternative implementation, the upstream implementation will be kept (to the extent it
+  doesn't break anything or conflict with other features).
+
 This repository holds 2 important branches:
+
 - `main`: a copy of upstream `main`.
-- `fork`: the default branch, in which PRs are merged. It is regulary
-  merged with `main`.
-  
+- `fork`: the default branch, in which PRs are merged. It is regulary merged with
+  `main`.
+
 ## How to report a bug
 
-Please be mindful that if a bug is not related to the specific
-features developed in this repository, but rather upstream, it should
-be opened in [dbt-docs](https://github.com/dbt-labs/dbt-docs).
+Please be mindful that if a bug is not related to the specific features developed in
+this repository, but rather upstream, it should be opened in
+[dbt-docs](https://github.com/dbt-labs/dbt-docs).
 
-Feel free to open an issue in this repository to discuss a bug you
-encountered related to the specific features added in this fork, or
-for any question or suggestion.
+Feel free to open an issue in this repository to discuss a bug you encountered related
+to the specific features added in this fork, or for any question or suggestion.
 
 ## How to contribute
 
-Contributions are certainly welcome! Keep in mind however that
-contributions should ideally be submitted upstream, as to keep this
-fork from diverging.
+Contributions are certainly welcome! Keep in mind however that contributions should
+ideally be submitted upstream, as to keep this fork from diverging.
 
-New features must be accompanied by a new entry in the Changelog
-below, referencing the PR or issue opened upstream, to make it easy to
-keep track of the differences between upstream and this fork.
+New features must be accompanied by a new entry in the Changelog below, referencing the
+PR or issue opened upstream, to make it easy to keep track of the differences between
+upstream and this fork.
 
-Fixes related to features developed in this fork need an update in the
-Changelog entry related to the feature they are fixing.
+Fixes related to features developed in this fork need an update in the Changelog entry
+related to the feature they are fixing.
 
 PRs must be created against the `fork` branch.
 
-To help keep things trackable, the following branch naming conventions
-are used:
+To help keep things trackable, the following branch naming conventions are used:
+
 - New feature: `[username]/feature-[feature-name]`
 - Bug fix: `[username]/fix-[fix-name]`
 
 ## Changelog
 
 - Add support for rendering additional metadata
-    - Upstream issue: https://github.com/dbt-labs/dbt-docs/issues/424
-    - Fork PR: https://github.com/PicnicSupermarket/dbt-docs/pull/1
 
-  This enables users to add any metadata to dbt docs in a structured way. The key `meta.meta_docs` is treated
-  differently and rendered in a structured way on the webpage. The structure of `meta` and `meta_docs` should be
-  as follows:
+  - Upstream issue: https://github.com/dbt-labs/dbt-docs/issues/424
+  - Fork PR: https://github.com/PicnicSupermarket/dbt-docs/pull/1
+
+  This enables users to add any metadata to dbt docs in a structured way. The key
+  `meta.meta_docs` is treated differently and rendered in a structured way on the
+  webpage. The structure of `meta` and `meta_docs` should be as follows:
 
   ```
       meta:
@@ -70,21 +68,22 @@ are used:
             - bla: bla
   ```
 
-  `meta_docs` enables users to add rows under the row that contains `meta`. It has to be a list of lists, where
-  each inner list contains dictionaries with one key-val pair. The
-  index of the outer list defines the position of the row, the index of the inner list(s) defines the position inside
-  the row.
+  `meta_docs` enables users to add rows under the row that contains `meta`. It has to be
+  a list of lists, where each inner list contains dictionaries with one key-val pair.
+  The index of the outer list defines the position of the row, the index of the inner
+  list(s) defines the position inside the row.
 
 - Add support for mermaid.js graphs
+
   - Upstream PR: https://github.com/dbt-labs/dbt-docs/pull/375
   - Upstream issue: https://github.com/dbt-labs/dbt-docs/issues/338
   - Fork PR: https://github.com/PicnicSupermarket/dbt-docs/pull/3
 
-  [mermaid.js](https://mermaid.js.org/) is a Javascript library to
-  render diagrams and flowcharts built from plain text.
+  [mermaid.js](https://mermaid.js.org/) is a Javascript library to render diagrams and
+  flowcharts built from plain text.
 
-  By using the syntax ```` ```mermaid```` in any markdown file, dbt
-  entities can enhance their catalog page with any mermaid.js diagram.
+  By using the syntax ` ```mermaid ` in any markdown file, dbt entities can enhance
+  their catalog page with any mermaid.js diagram.
 
 ## Changelog entry example
 

--- a/FORK.md
+++ b/FORK.md
@@ -56,7 +56,7 @@ are used:
     - Upstream issue: https://github.com/dbt-labs/dbt-docs/issues/424
     - Fork PR: https://github.com/PicnicSupermarket/dbt-docs/pull/1
 
-  To enable users in adding any metadata to dbt docs in a structured way. The key `meta.meta_docs` is treated
+  This enables users to add any metadata to dbt docs in a structured way. The key `meta.meta_docs` is treated
   differently and rendered in a structured way on the webpage. The structure of `meta` and `meta_docs` should be
   as follows:
 

--- a/FORK.md
+++ b/FORK.md
@@ -70,7 +70,7 @@ are used:
             - bla: bla
   ```
 
-  `meta_additional` enables users to add rows under the row that contains `meta`. It has to be a list of lists, where
+  `meta_docs` enables users to add rows under the row that contains `meta`. It has to be a list of lists, where
   each inner list contains dictionaries with one key-val pair. The
   index of the outer list defines the position of the row, the index of the inner list(s) defines the position inside
   the row.

--- a/FORK.md
+++ b/FORK.md
@@ -53,17 +53,17 @@ are used:
 ## Changelog
 
 - Add support for rendering additional metadata
-    - Upstream issue: https://github.com/dbt-labs/dbt-core/issues/7021
+    - Upstream issue: https://github.com/dbt-labs/dbt-docs/issues/424
     - Fork PR: https://github.com/PicnicSupermarket/dbt-docs/pull/1
 
-  To enable users in adding any metadata to dbt docs in a structured way. The key `meta.additional_meta` is treated
-  differently and rendered in a structured way on the webpage. The structure of `meta` and `additional_meta` should be
+  To enable users in adding any metadata to dbt docs in a structured way. The key `meta.meta_docs` is treated
+  differently and rendered in a structured way on the webpage. The structure of `meta` and `meta_docs` should be
   as follows:
 
   ```
       meta:
         meta_stuff: meta_stuff
-        additional_meta:
+        meta_docs:
           - - foo: bar
             - baz: qux
           - - fiz: buz

--- a/src/app/components/table_details/table_details.html
+++ b/src/app/components/table_details/table_details.html
@@ -13,8 +13,8 @@
                             </dl>
                         </div>
                     </div>
-                    <div class="something" ng-if="hasData(additional_meta)">
-                         <div class="detail-group" ng-repeat="row in additional_meta">
+                    <div class="something" ng-if="hasData(meta_docs)">
+                         <div class="detail-group" ng-repeat="row in meta_docs">
                             <div class="detail-body">
                                 <dl class="detail"
                                     ng-repeat="column in row">

--- a/src/app/components/table_details/table_details.html
+++ b/src/app/components/table_details/table_details.html
@@ -14,12 +14,13 @@
                         </div>
                     </div>
                     <div class="something" ng-if="hasData(meta_docs)">
-                         <div class="detail-group" ng-repeat="row in meta_docs">
+                        <div class="detail-group" ng-repeat="row in meta_docs">
                             <div class="detail-body">
-                                <dl class="detail"
-                                    ng-repeat="column in row">
-                                    <dt class="detail-label" ng-repeat="(k, _) in column">{{ k }}</dt>
-                                    <dd class="detail-value" ng-repeat="(_, v) in column">{{ v }}</dd>
+                                <dl class="detail" ng-repeat="column in row">
+                                    <div ng-repeat="(k, v) in column">
+                                        <dt class="detail-label">{{ k }}</dt>
+                                        <dd class="detail-value">{{ v }}</dd>
+                                    </div>
                                 </dl>
                             </div>
                         </div>

--- a/src/app/components/table_details/table_details.html
+++ b/src/app/components/table_details/table_details.html
@@ -13,6 +13,17 @@
                             </dl>
                         </div>
                     </div>
+                    <div class="something" ng-if="hasData(additional_meta)">
+                         <div class="detail-group" ng-repeat="row in additional_meta">
+                            <div class="detail-body">
+                                <dl class="detail"
+                                    ng-repeat="column in row">
+                                    <dt class="detail-label" ng-repeat="(k, _) in column">{{ k }}</dt>
+                                    <dd class="detail-value" ng-repeat="(_, v) in column">{{ v }}</dd>
+                                </dl>
+                            </div>
+                        </div>
+                    </div>
                     <div class="detail-group">
                         <div class="detail-body">
                             <dl class='detail' ng-if="model.tags != undefined && exclude.indexOf('tags') == -1">

--- a/src/app/components/table_details/table_details.js
+++ b/src/app/components/table_details/table_details.js
@@ -180,9 +180,9 @@ angular
                 var sources_meta = nv.hasOwnProperty('sources') ? nv.sources[0] != undefined ? nv.sources[0].source_meta : null : null;
                 scope.meta = nv.meta || sources_meta;
 
-                if (scope.meta && scope.meta.additional_meta) {
-                    scope.additional_meta = scope.meta.additional_meta;
-                    delete scope.meta.additional_meta;
+                if (scope.meta && scope.meta.meta_docs) {
+                    scope.meta_docs = scope.meta.meta_docs;
+                    delete scope.meta.meta_docs;
                 }
 
                 scope.details = getBaseStats(nv);

--- a/src/app/components/table_details/table_details.js
+++ b/src/app/components/table_details/table_details.js
@@ -179,7 +179,12 @@ angular
 
                 var sources_meta = nv.hasOwnProperty('sources') ? nv.sources[0] != undefined ? nv.sources[0].source_meta : null : null;
                 scope.meta = nv.meta || sources_meta;
-                
+
+                if (scope.meta && scope.meta.additional_meta) {
+                    scope.additional_meta = scope.meta.additional_meta;
+                    delete scope.meta.additional_meta;
+                }
+
                 scope.details = getBaseStats(nv);
                 scope.extended = getExtendedStats(nv.stats);
 


### PR DESCRIPTION
### Description

Render `meta.aditional_meta` in dbt docs. `meta_additional` should be a list of lists, where each inner list contains dictionaries with one key-val pair. The index of the outer list defines the position of the row, the index of the inner list(s) defines the position inside the row. 

```
    meta:
      meta_stuff: meta_stuff
      additional_docs:
        - - foo: bar
          - baz: qux
        - - fiz: buz
          - bla: bla
```




 