### PR TITLE
Add tooltip to meta_docs

### DIFF
--- a/src/app/components/table_details/table_details.html
+++ b/src/app/components/table_details/table_details.html
@@ -20,7 +20,7 @@
                             <div class="detail-body">
                                 <dl class="detail" ng-repeat="column in row">
                                     <div ng-repeat="(k, v) in column">
-                                        <dt class="detail-label">{{ k }}</dt>
+                                        <dt data-toggle="tooltip" title="{{ k }}" class="detail-label">{{ k }}</dt>
                                         <dd class="detail-value">{{ v }}</dd>
                                     </div>
                                 </dl>


### PR DESCRIPTION
### Description

This PR adds a tooltip to meta_docs section in the data catalog. For now, it's just displaying the key value of the meta_docs that has been generated. We should consider to display different values as tooltip.




### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 